### PR TITLE
Don't abord build on lint errors

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,6 +17,9 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    lintOptions {
+        abortOnError false
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Hello,

`assembleRelease` fails because of some missing translation errors.
This patch makes the build continue even when it finds some lint errors.